### PR TITLE
Minor suggestion to vim-plug block

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,9 @@ return {
 Using [vim-plug](https://github.com/junegunn/vim-plug)
 
 ```viml
+call plug#begin()
 Plug 'fabridamicelli/cronex.nvim'
+call plug#end()
 
 lua <<EOF
 require("cronex").setup({})


### PR DESCRIPTION
Include calls `begin()` and `end()`. If you put the `require("cronex").setup({})` inside the plug block, it will fail.

Maybe it's excessive, but "explicit is better than implicit" :wink: 
What do you think?

Relates to #5 